### PR TITLE
Add publications index and align v0.2.1 research baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.2.1 - Research Baseline
+
+- Established the immutable baseline for the first peer-reviewed EAIMS paper
+- Corrected v0.2 document-version headings and citation metadata
+- Clarified normative evidence requirements versus executable validation
+- Aligned scoring documentation with the equal-weight v0.2 reference implementation
+- Added reproducible computational sensitivity-analysis materials for Paper 01
+- Added a central publications index for the English and Persian EAIMS books and research outputs
+
 ## 0.2.0 — Executable Community Draft
 
 - Added deterministic Python scoring, validation, CLI, Markdown/HTML reports, and nine automated tests

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > An open, vendor-neutral, evidence-based, and executable specification for enterprise AI maturity.
 
-**Version:** 0.2.1 Executable Community Draft  
+**Version:** 0.2.1 Research Baseline  
 **Status:** Public Review and Pilot Preparation  
 **Documentation and assessment content:** CC BY 4.0  
 **Code, workflows, and schemas:** Apache-2.0
@@ -82,6 +82,10 @@ v0.2 is executable and internally tested. It has **not yet** completed independe
 ## Contributing and support
 
 Contributions require DCO sign-off and rights disclosure. See [Contributing](CONTRIBUTING.md), [Reviewer Program](REVIEWERS.md), [Sponsorship Policy](SPONSORSHIP.md), and [Financial Transparency](FINANCIAL_TRANSPARENCY.md). Funding cannot buy changes, favorable scores, certification, endorsement, or governance control.
+
+## Publications
+
+Books and research outputs: [EAIMS Publications](publications/README.md)
 
 ## Project website
 

--- a/publications/README.md
+++ b/publications/README.md
@@ -1,0 +1,44 @@
+# EAIMS Publications
+
+This page is the central index for books and peer-reviewed research associated with the Enterprise AI Maturity Standard (EAIMS).
+
+## Books
+
+### Enterprise AI Maturity Standard (EAIMS)
+
+**Author:** Elias Naserkhaki  
+**Language:** English  
+**Access:** Free and openly available  
+**Zenodo:** https://zenodo.org/records/21853733  
+**DOI:** https://doi.org/10.5281/zenodo.21853733
+
+The authoritative published book files and version history are maintained on Zenodo rather than duplicated in this repository.
+
+### Persian edition
+
+**Author:** Elias Naserkhaki  
+**Language:** Persian  
+**Access:** Free and openly available  
+**Zenodo:** https://zenodo.org/records/21863979  
+**DOI:** https://doi.org/10.5281/zenodo.21863979
+
+The authoritative Persian book files and version history are maintained on Zenodo rather than duplicated in this repository.
+
+## Peer-reviewed Research
+
+### Paper 01
+
+**Title:** *EAIMS: An Evidence-Grounded and Executable Framework for Enterprise AI Maturity Assessment*  
+**Author:** Elias Naserkhaki  
+**Status:** Manuscript submitted for peer review  
+**Reproducibility package:** [`research/paper-01/`](../research/paper-01/)  
+**Research baseline:** EAIMS `v0.2.1`  
+**Baseline commit:** `6d1dbf1`
+
+The manuscript itself is not stored in this repository while it is under journal review. The repository contains only the reproducibility materials and immutable research baseline needed to support the scholarly work.
+
+## Citation guidance
+
+For the books, cite the corresponding Zenodo DOI.
+
+For Paper 01 reproducibility, cite the immutable EAIMS `v0.2.1` release and commit `6d1dbf1`, not the moving `main` branch.

--- a/research/paper-01/README.md
+++ b/research/paper-01/README.md
@@ -1,4 +1,4 @@
-# EAIMS Paper 01 — Reproducibility Package
+# EAIMS Paper 01 - Reproducibility Package
 
 This directory supports the first research paper based on EAIMS.
 
@@ -29,17 +29,16 @@ The sensitivity script writes:
 
 The reference EAIMS v0.2 engine uses equal weighting and a fixed critical gate threshold of 2.0.
 
-Alternative weights, gate thresholds, confidence thresholds, and critical-set memberships in this directory are **external computational sensitivity simulations**. They are research experiments and are not normative EAIMS v0.2 scoring rules.
+Alternative weights, gate thresholds, confidence thresholds, and critical-set memberships in this directory are external computational sensitivity simulations. They are research experiments and are not normative EAIMS v0.2 scoring rules.
 
 The analysis evaluates computational behavior and classification stability. It does not establish construct validity, predictive validity, inter-rater reliability, or multi-organization generalizability.
 
 ## Research baseline
 
-Before manuscript submission, replace the placeholders below with the immutable release identifiers used by the paper:
-
 - EAIMS release: `v0.2.1`
-- Git commit SHA: `<INSERT_SHA>`
-- Research artifact DOI: `<INSERT_VERSIONED_DOI>`
+- Git commit SHA: `6d1dbf1`
 - Book DOI: `10.5281/zenodo.21853733`
+
+The manuscript is currently under peer review. A research-artifact DOI should be added here only after a versioned archive DOI has actually been minted.
 
 Do not cite `main` as the reproducibility baseline.


### PR DESCRIPTION
Adds the EAIMS publications index for the English and Persian books, aligns Paper 01 reproducibility metadata with the v0.2.1 research baseline, and updates README and CHANGELOG.