### PR TITLE
Add approved implementations registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ EAIMS supports predictive ML, generative AI, RAG, agents, third-party services, 
 
 EAIMS was founded and initially authored by **Elias Naserkhaki**, registrant and founding steward of **eaims.org**. Founder attribution records project origin and stewardship; it does not create accredited standards authority or override published governance.
 
-EAIMS is not an ISO, IEC, ANSI, governmental, or accredited standard. It does not provide certification, legal compliance, safety assurance, or endorsement. See [Disclaimer](DISCLAIMER.md), [IP Policy](IP_POLICY.md), [Origin](ORIGIN.md), and [Trademark Policy](TRADEMARK.md).
+EAIMS is not an ISO, IEC, ANSI, governmental, or accredited standard. It does not provide certification, legal compliance, or safety assurance. A narrowly scoped implementation listing, when present in the [public registry](docs/approved-implementations.md), is not certification or approval of customer results. See [Disclaimer](DISCLAIMER.md), [IP Policy](IP_POLICY.md), [Origin](ORIGIN.md), and [Trademark Policy](TRADEMARK.md).
 
 ## Quick start
 
@@ -70,6 +70,7 @@ docker run --rm -p 8080:80 eaims
 | Evidence | [Evidence Catalog](assessment/evidence-catalog.json) |
 | Facilitation | [Assessor Handbook](docs/Assessor-Handbook.md) |
 | Implementation claims | [Conformance](docs/Conformance.md) |
+| Approved implementations | [Implementation Registry](docs/approved-implementations.md) |
 | Research pilots | [Pilot Protocol](docs/Pilot-Protocol.md) |
 | Future benchmarking | [Benchmark Protocol](docs/Benchmark-Protocol.md) |
 | External frameworks | [Independent Conceptual Crosswalk](docs/Standards-Crosswalk.md) |

--- a/TRADEMARK.md
+++ b/TRADEMARK.md
@@ -2,8 +2,8 @@
 
 The EAIMS name and visual identity identify this open specification project. Content and code licenses do not authorize branding that implies source, sponsorship, certification, accreditation, or endorsement.
 
-Permitted descriptive uses include “Based on EAIMS v0.2,” “implements an adapted EAIMS assessment,” and “independent implementation of EAIMS.” Modified implementations MUST disclose modifications and state that they are not endorsed by EAIMS.
+Permitted descriptive uses include “Based on EAIMS v0.2,” “implements an adapted EAIMS assessment,” and “independent implementation of EAIMS.” Modified implementations MUST disclose modifications and state that they are not endorsed by EAIMS unless a current, narrowly scoped written permission is recorded in the public [Approved Implementations Registry](docs/approved-implementations.md).
 
-Written permission is required to claim an official EAIMS product, service, certification, accreditation, assessor, training provider, implementation, endorsement, or exclusive partnership. Do not use EAIMS or confusingly similar branding as a company, product, service, domain, certification, or training-program name without permission.
+Written permission is required to claim an official EAIMS product, service, certification, accreditation, assessor, training provider, approved implementation, endorsement, or exclusive partnership. An approved registry listing permits only the exact implementation wording and scope recorded in that listing. Do not use EAIMS or confusingly similar branding as a company, product, service, domain, certification, or training-program name without permission.
 
 Fair descriptive use, commentary, criticism, citation, and comparison remain permitted where no endorsement is implied. No use of `®` is authorized unless the relevant mark is registered. This policy does not claim registration. EAIMS has no affiliation with OpenAI or any unrelated organization.

--- a/docs/approved-implementations.md
+++ b/docs/approved-implementations.md
@@ -1,0 +1,73 @@
+# EAIMS Approved Implementations Registry
+
+This registry lists products and services that the EAIMS project has reviewed for a defined implementation scope and a named EAIMS release.
+
+Registry approval means only that the reviewed implementation satisfied the published listing criteria at the recorded review date. It is not certification, accreditation, legal or regulatory approval, security assurance, validation of a customer's assessment result, or a guarantee of continued conformance.
+
+## Listing criteria
+
+An approved listing MUST:
+
+1. identify the implemented EAIMS release and conformance class;
+2. preserve the applicable capability identifiers, maturity anchors, scoring bands, and critical gates, or disclose every material modification;
+3. distinguish maturity scores from evidence confidence and review status where the claimed class requires it;
+4. provide clear EAIMS attribution and applicable license notices;
+5. avoid prohibited certification, accreditation, partnership, and regulatory-compliance claims;
+6. document the product scope, material limitations, and review evidence;
+7. complete maintainer review, including conflict-of-interest disclosure; and
+8. accept re-review after a material product or EAIMS release change.
+
+The registry status applies only to the version and scope shown below. Implementers remain responsible for security, privacy, availability, local law, customer communications, and the accuracy of their own software and services.
+
+## Status definitions
+
+| Status | Meaning |
+|---|---|
+| Approved | The named version and scope passed project review against the listing criteria. |
+| Provisional | Initial review passed, but one or more stated follow-up items remain open. |
+| Suspended | The listing is temporarily inactive pending clarification or remediation. |
+| Withdrawn | The implementation is no longer listed as approved. |
+
+## Registered implementations
+
+### HM-0001 — Hoosh Madar
+
+| Field | Record |
+|---|---|
+| Product | [Hoosh Madar](https://hooshmadar.ir/) |
+| Provider | Hoosh Madar |
+| Registry status | **Approved** |
+| Listed first | 2026-08-12 |
+| EAIMS release | EAIMS v0.2.1 Research Baseline |
+| Conformance claim | EAIMS v0.2 Assessment Compatible; Persian localized and modified implementation |
+| Approved scope | Self-assessment workflow, 27-capability questionnaire, six-level maturity anchors, critical-gate scoring, management report, and transformation-roadmap workflow |
+| Delivery model | Independently developed PHP/MySQL web application for self-hosted deployment |
+| Material modifications | Persian localization, user-facing diagnostic wording, level-specific workflows, product UX, reporting, and roadmap management |
+| Limitations | Listing does not approve hosting configurations, customer data handling, assessment evidence, individual results, assessor independence, or legal and regulatory compliance |
+| Re-review trigger | Material scoring change, removal of required capabilities or gates, incompatible EAIMS upgrade, or a substantive change to the approved scope |
+
+#### Review and conflict disclosure
+
+Hoosh Madar is the first implementation entered in this registry. Elias Naserkhaki is the founding steward of EAIMS and is also associated with Hoosh Madar. This related-party relationship creates an actual conflict of interest and is disclosed here.
+
+The initial listing is a maintainer review against the criteria above, not an independent third-party audit. A future independent registry reviewer SHOULD re-evaluate this entry when the EAIMS reviewer program is operational. Until then, Hoosh Madar MUST describe itself as an “EAIMS approved implementation” only with a direct link to this record and MUST NOT use “EAIMS Certified,” “official EAIMS assessor,” or equivalent certification language.
+
+## Applying for a listing
+
+Open a repository issue or pull request containing:
+
+- legal or public provider name and product URL;
+- product version and implemented EAIMS release;
+- requested conformance class and scope;
+- a modification and limitations statement;
+- reproducible review evidence or a private-review plan for sensitive material;
+- security and privacy contact details; and
+- all relevant commercial and reviewer conflicts.
+
+Approval, suspension, and withdrawal decisions MUST be recorded through the public repository history. Payment, sponsorship, or commercial relationships cannot purchase or guarantee a listing.
+
+## Reporting a concern
+
+Report inaccurate claims or suspected loss of conformance through the repository issue tracker. Report security vulnerabilities using [SECURITY.md](../SECURITY.md), not a public issue.
+
+See also [EAIMS Conformance](Conformance.md), [Governance](../GOVERNANCE.md), and the [Name and Mark Policy](../TRADEMARK.md).


### PR DESCRIPTION
## Summary

- add a public EAIMS Approved Implementations Registry
- define transparent listing criteria, statuses, limitations, re-review triggers, and application requirements
- register Hoosh Madar as the first entry (`HM-0001`) for EAIMS v0.2.1
- update the README and trademark policy to distinguish scoped registry approval from certification, accreditation, or approval of customer results

## Why

Hoosh Madar and future implementers need a stable, public record for narrowly scoped EAIMS implementation-review decisions. Keeping the decision in repository history makes the permitted claim, reviewed scope, limitations, and status auditable.

## Governance and conflict disclosure

Elias Naserkhaki is the founding steward of EAIMS and is also associated with Hoosh Madar. The registry entry explicitly records this related-party conflict and states that the initial listing is a maintainer review, not an independent third-party audit. It also calls for independent re-review when the reviewer program is operational.

## Validation

- `PYTHONPATH=src python -m unittest discover -s tests -v` — 9 tests passed
- `git diff --check` — passed
- documentation links and referenced repository paths checked locally

## Review focus

Please verify:

- whether “Approved” is the desired initial status rather than “Provisional”
- the exact approved scope and conformance wording
- the conflict-of-interest language
- the future application and re-review process

AI assistance was used to draft and structure the documentation; maintainer judgment is required for the registry decision.