### PR TITLE
Harden EAIMS v1 input validation and review integrity

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,6 +40,7 @@ jobs:
           /tmp/eaims-wheel-venv/bin/eaims-validate
           /tmp/eaims-wheel-venv/bin/eaims validate-fixture "$GITHUB_WORKSPACE/reference-implementations/ri-01-api-consumed-analytics/input/fixture.yaml"
           /tmp/eaims-wheel-venv/bin/eaims assess "$GITHUB_WORKSPACE/reference-implementations/ri-01-api-consumed-analytics/input/fixture.yaml" --out /tmp/eaims-wheel-ri01
+          /tmp/eaims-wheel-venv/bin/eaims review summarize "$GITHUB_WORKSPACE/validation/review-workflow-fixture.yaml" --out /tmp/eaims-wheel-review --fail-on-unmet
       - name: Dependency audit
         run: |
           python -m pip install pip-audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased — v1 input and review hardening
+
+- Reject empty evidence collection times, ambiguous input types, non-finite numbers and duplicate YAML mapping keys before assessment.
+- Add v1 fixture and result schemas while preserving legacy contracts and existing valid reference results.
+- Reject duplicate review/finding identities; preserve the original ledger when applying resolutions.
+- Resolve review schemas through the shared installed-package data root.
+- Add optional `review summarize --fail-on-unmet` for automation with explicit exit semantics.
+- Add a v1 quickstart and clearly label legacy questionnaire, scoring and browser resources.
+- Extend regression coverage and installed-wheel review checks.
+
+These changes do not alter the frozen normative specification or retroactively change the published 1.0.0 release evidence.
+
 ## 0.2.1 - Research Baseline
 
 - Established the immutable baseline for the first peer-reviewed EAIMS paper

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ EAIMS 1.0 moves the project from a research-baseline maturity model toward an ex
 
 A central design principle is that AI maturity is not maximum automation. Mature organizations determine where automation creates value, where human oversight is necessary, and where accountability must remain human.
 
+## Start with EAIMS 1.0
+
+Follow the [v1 assessment guide](docs/ASSESSMENT-V1.md) for installation, a runnable example, output interpretation and review automation. The reference example detects a synthetic agent exceeding its financial authority; the report identifies the breached gates so the assessor can define a corrective action.
+
+The browser interface in `site/`, the questionnaire in `assessment/`, and the `validate`, `score`, `report` commands are **legacy v0.2.x** resources. Use `validate-fixture` and `assess` for v1.0; do not relabel legacy scores as v1 results.
+
 ## Executable reference implementation
 
 The Python package validates structured assessments, evaluates evidence and requirements, applies anchor eligibility and gates, produces deterministic results and reports, and supports structured review operations.

--- a/assessment/questionnaire.md
+++ b/assessment/questionnaire.md
@@ -1,5 +1,7 @@
 # EAIMS Assessment Questionnaire
 
+> **Legacy v0.2.x resource.** This file does not define the EAIMS 1.0 workflow. Start with the [EAIMS 1.0 assessment guide](../docs/ASSESSMENT-V1.md).
+
 ## Q001 — AI vision and strategic alignment
 
 Which statement best describes the organization's current capability for ai vision and strategic alignment?

--- a/assessment/scoring-methodology.md
+++ b/assessment/scoring-methodology.md
@@ -1,5 +1,7 @@
 # EAIMS v0.2 Scoring Methodology
 
+> **Legacy v0.2.x resource.** This file does not define the EAIMS 1.0 workflow. Start with the [EAIMS 1.0 assessment guide](../docs/ASSESSMENT-V1.md).
+
 ## 1. Capability scores
 
 Each of 27 capabilities receives an integer score from 0 to 5 using the highest maturity anchor fully supported by evidence. If evidence is incomplete, select the lower defensible score. In executable conformance, Level 3–5 scores require at least one evidence identifier.

--- a/docs/ASSESSMENT-V1.md
+++ b/docs/ASSESSMENT-V1.md
@@ -1,0 +1,68 @@
+# EAIMS 1.0 assessment guide
+
+## Choose the correct workflow
+
+EAIMS 1.0 uses 8 dimensions, 30 capabilities and levels L1–L5. The v0.2.x questionnaire, browser interface and `validate`, `score`, `report` commands remain available for historical compatibility. Their results are not interchangeable with v1 results.
+
+## Run a complete synthetic example
+
+From a checkout of the repository, using Python 3.10 or later:
+
+```bash
+python -m pip install -e '.[test]'
+eaims-validate
+eaims validate-fixture reference-implementations/ri-02-enterprise-service-agent/input/fixture.yaml
+eaims assess reference-implementations/ri-02-enterprise-service-agent/input/fixture.yaml --out run-output
+```
+
+Open `run-output/report.md` and `run-output/result.json`. This targeted example reports a financial permission-envelope violation and breached G3-04 and G3-10 gates. It produces no enterprise-wide maturity index. The breach is deliberately injected into synthetic data; the example is not a customer deployment.
+
+A useful assessor response is to identify the action that exceeded authority, verify the source event and approved limit, assign an owner to investigate enforcement, and document retest evidence before reassessment. The engine reports the finding; it does not itself suspend a production agent or implement remediation.
+
+## Prepare a real assessment input
+
+Copy a reference fixture into a private working location and replace its synthetic values and evidence references. Define the assessment scope, system, risk profile and evidence cutoff before scoring.
+
+- `assessment`: stable assessment identifier, FULL/PARTIAL/TARGETED scope type and a timezone-aware cutoff timestamp.
+- `system` and `risk_profile`: the system context and the impact, autonomy, reversibility, scale and velocity classifications.
+- `capabilities`: canonical capability IDs, applicability, observed anchors and completed operating/adaptation cycles.
+- `evidence`: identifiable sources, evidence class, confidence, nature, validity and collection time. Quote YAML timestamps, for example `"2026-09-09T07:00:00Z"`.
+- `requirement_results`: canonical requirement IDs, assessor determinations and supporting evidence references. SATISFIED SHALL/SHALL_NOT determinations require evidence references.
+- `gate_inputs`: explicit PASS/BREACH/INCOMPLETE/NOT_APPLICABLE assertions, or actual booleans. Modeled automated G2/G3 findings take precedence over manual assertions.
+- Agent or high-impact scenarios: supply the permission envelope, decision policy, events and relevant controls used by that scenario.
+
+Use actual YAML booleans (`true`, `false`), not quoted boolean strings. Cycle counts are nonnegative integers. Financial values are finite nonnegative numbers, not strings or booleans; use consistent monetary units for the approved limit and events. Duplicate YAML keys, duplicate evidence/capability/requirement IDs and broken evidence references are rejected. Missing audit fields can still yield explicit incomplete-audit findings; do not interpret absent events as proof that controls operated.
+
+Run `validate-fixture` before `assess`. Structural validity does not establish authenticity, completeness or effectiveness of organizational evidence. Additional contextual fields are preserved in input but may not be evaluated by the engine.
+
+## Interpret the output
+
+| Output | Meaning |
+|---|---|
+| `capability_results` | Awarded level or an explicit INDETERMINATE / NOT_APPLICABLE / NOT_ASSESSED state, with available rationale and traces |
+| `dimension_profile` | Profile across represented dimensions |
+| `gate_results` | Explicit control gate results; inspect breaches and incomplete gates separately from maturity scores |
+| `coverage` | Scope and determinate-evidence coverage used by the engine |
+| `enterprise_index` | Available only for FULL assessments meeting the implemented coverage criteria |
+| `indicative_scoped_index` | Scoped indicator for PARTIAL assessments or insufficiently covered FULL assessments |
+| `result_hash` | Deterministic hash of the result content before adding the hash field; not a digital signature or proof of evidence authenticity |
+
+TARGETED assessments produce no overall index. A FULL assessment must contain all 30 canonical capabilities; the engine also checks critical-capability assessment, determinate coverage and dimension representation. A maturity result does not establish certification, compliance or production safety. Keep gate findings, confidence and evidence limitations visible when sharing the report.
+
+## Automate review exit checks
+
+```bash
+eaims review summarize validation/review-workflow-fixture.yaml --out review-output --fail-on-unmet
+```
+
+The included fixture is synthetic and only demonstrates the workflow. Replace it with actual review records and resolutions for real review decisions. Independent-review classification is supplied by the record; the engine does not authenticate a reviewer's independence.
+
+With `--fail-on-unmet`, exit 0 means the modeled review exit criteria were met; exit 1 means they were not met. In both cases reports are written. Invalid review input exits 2. Without the option, successful report generation retains exit 0 even if criteria are unmet. Duplicate review IDs, finding keys and resolution IDs are rejected rather than overwritten.
+
+Assessment commands exit 1 for rejected fixtures and 2 for loading/parsing errors. Use the shared package data root (`EAIMS_ROOT` when needed); review commands now resolve installed schemas in the same way as assessment commands.
+
+## Contracts and evidence boundary
+
+Use [assessment-fixture-v1.schema.json](../schemas/assessment-fixture-v1.schema.json) and [assessment-result-v1.schema.json](../schemas/assessment-result-v1.schema.json) for v1 integration. Semantic checks in the engine supplement the input schema. Legacy schemas remain unchanged.
+
+Some machine rules inspect supplied flags or references. They do not independently inspect enterprise access controls, logs or monitoring systems. Production evidence collection, empirical calibration and independent multi-organization validation remain outside the demonstrated boundary; see [VALIDATION.md](../VALIDATION.md).

--- a/docs/Standards-Crosswalk.md
+++ b/docs/Standards-Crosswalk.md
@@ -1,5 +1,7 @@
 # Independent Conceptual Crosswalk — EAIMS v0.2
 
+> **Legacy v0.2.x resource.** This file does not define the EAIMS 1.0 workflow. Start with the [EAIMS 1.0 assessment guide](../docs/ASSESSMENT-V1.md).
+
 This is a high-level analytical aid based on publicly identifiable themes. It does not reproduce protected standards text and does not establish alignment, equivalence, certification, endorsement, or legal compliance. Obtain and use authoritative standards through their publishers.
 
 | EAIMS area | NIST AI RMF theme | ISO/IEC 42001 public subject | Other public reference | Relationship |

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -1,5 +1,13 @@
 # EAIMS Schemas
 
-`assessment-result.schema.json` defines a minimal interoperable format for EAIMS assessment results.
+| Workflow | Input | Output |
+|---|---|---|
+| EAIMS 1.0 reference engine (`validate-fixture`, `assess`) | `assessment-fixture-v1.schema.json` | `assessment-result-v1.schema.json` |
+| Legacy v0.2.x (`validate`, `score`, `report`) | `assessment-input.schema.json` / `assessment.schema.json` | `assessment-result.schema.json` |
+| Review | `review-feedback.schema.json`, `review-resolution.schema.json` | Review summary and findings ledger |
 
-Implementers should avoid storing confidential evidence directly in shared result files. Use references to appropriately protected evidence repositories.
+The v1 input schema checks the types of supported executable fields. Additional properties remain allowed for context and extensions; their presence does not mean the engine evaluates them. The engine separately validates canonical references, applicability rationales, evidence references, assessment scope and cutoff timestamps. Finite-number and recursive-data checks run before schema validation. JSON Schema date-time validation requires a format checker.
+
+The v1 result schema describes the stable report envelope and FULL/PARTIAL/TARGETED index semantics. It is not proof of evidence authenticity or enterprise control effectiveness. The normative provenance remains `1.0.0-fc16`.
+
+See the [v1 assessment guide](../docs/ASSESSMENT-V1.md). Keep confidential evidence in protected repositories and publish only appropriate references.

--- a/schemas/assessment-fixture-v1.schema.json
+++ b/schemas/assessment-fixture-v1.schema.json
@@ -1,0 +1,666 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eaims.org/schemas/v1/assessment-fixture.schema.json",
+  "title": "EAIMS 1.0 executable assessment fixture",
+  "description": "Structural validation; canonical IDs, evidence references and cutoff semantics are checked by the engine. Extension properties are preserved.",
+  "type": "object",
+  "properties": {
+    "assessment": {
+      "type": "object",
+      "properties": {
+        "assessment_id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\S"
+        },
+        "assessment_type": {
+          "type": "string",
+          "enum": [
+            "FULL",
+            "PARTIAL",
+            "TARGETED"
+          ]
+        },
+        "evidence_cutoff_time": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\S",
+          "format": "date-time"
+        }
+      },
+      "required": [
+        "assessment_id",
+        "assessment_type",
+        "evidence_cutoff_time"
+      ]
+    },
+    "system": {
+      "type": "object",
+      "properties": {
+        "material": {
+          "type": "boolean"
+        },
+        "agentic": {
+          "type": "boolean"
+        },
+        "persistent_memory": {
+          "type": "boolean"
+        },
+        "autonomy": {
+          "type": "string",
+          "enum": [
+            "A0",
+            "A1",
+            "A2",
+            "A3",
+            "A4",
+            "A5"
+          ]
+        },
+        "approved_autonomy": {
+          "type": "string",
+          "enum": [
+            "A0",
+            "A1",
+            "A2",
+            "A3",
+            "A4",
+            "A5"
+          ]
+        },
+        "observed_autonomy": {
+          "type": "string",
+          "enum": [
+            "A0",
+            "A1",
+            "A2",
+            "A3",
+            "A4",
+            "A5"
+          ]
+        },
+        "impact": {
+          "type": "string",
+          "enum": [
+            "I0",
+            "I1",
+            "I2",
+            "I3",
+            "I4"
+          ]
+        },
+        "system_id": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\S"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\S"
+        }
+      }
+    },
+    "risk_profile": {
+      "type": "object",
+      "properties": {
+        "impact": {
+          "type": "string",
+          "enum": [
+            "I0",
+            "I1",
+            "I2",
+            "I3",
+            "I4"
+          ]
+        },
+        "autonomy": {
+          "type": "string",
+          "enum": [
+            "A0",
+            "A1",
+            "A2",
+            "A3",
+            "A4",
+            "A5"
+          ]
+        },
+        "reversibility": {
+          "type": "string",
+          "enum": [
+            "R0",
+            "R1",
+            "R2",
+            "R3",
+            "R4"
+          ]
+        },
+        "scale": {
+          "type": "string",
+          "enum": [
+            "S0",
+            "S1",
+            "S2",
+            "S3",
+            "S4"
+          ]
+        },
+        "velocity": {
+          "type": "string",
+          "enum": [
+            "V0",
+            "V1",
+            "V2",
+            "V3",
+            "V4"
+          ]
+        }
+      },
+      "required": [
+        "impact",
+        "autonomy",
+        "reversibility",
+        "scale",
+        "velocity"
+      ]
+    },
+    "evidence": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "evidence_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "class": {
+            "type": "string",
+            "enum": [
+              "E1",
+              "E2",
+              "E3",
+              "E4"
+            ]
+          },
+          "confidence": {
+            "type": "string",
+            "enum": [
+              "C0",
+              "C1",
+              "C2",
+              "C3",
+              "C4"
+            ]
+          },
+          "validity": {
+            "type": "string",
+            "enum": [
+              "VALID",
+              "STALE",
+              "INVALIDATED",
+              "CONFLICTED",
+              "UNVERIFIED"
+            ]
+          },
+          "nature": {
+            "type": "string",
+            "enum": [
+              "SUPPORTING",
+              "COUNTER",
+              "ABSENCE",
+              "CONTEXT"
+            ]
+          },
+          "source": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "collected_at": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "evidence_id",
+          "class",
+          "confidence",
+          "validity",
+          "nature",
+          "source",
+          "collected_at"
+        ]
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "capability_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "applicability": {
+            "type": "string",
+            "enum": [
+              "APPLICABLE",
+              "CONDITIONALLY_APPLICABLE",
+              "NOT_APPLICABLE",
+              "NOT_ASSESSED"
+            ]
+          },
+          "applicability_rationale": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "anchor_observed": {
+            "type": "object",
+            "properties": {
+              "L1": {
+                "type": "boolean"
+              },
+              "L2": {
+                "type": "boolean"
+              },
+              "L3": {
+                "type": "boolean"
+              },
+              "L4": {
+                "type": "boolean"
+              },
+              "L5": {
+                "type": "boolean"
+              }
+            },
+            "additionalProperties": false
+          },
+          "operating_cycles": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "adaptation_cycles": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "required": [
+          "capability_id"
+        ]
+      }
+    },
+    "requirement_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "requirement_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "SATISFIED",
+              "PARTIALLY_SATISFIED",
+              "NOT_SATISFIED",
+              "INSUFFICIENT_EVIDENCE",
+              "NOT_APPLICABLE"
+            ]
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            },
+            "uniqueItems": true
+          },
+          "applicability_rationale": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "conflict": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "requirement_id",
+          "result"
+        ]
+      }
+    },
+    "gate_inputs": {
+      "type": "object",
+      "additionalProperties": {
+        "anyOf": [
+          {
+            "type": "boolean"
+          },
+          {
+            "type": "string",
+            "enum": [
+              "PASS",
+              "BREACH",
+              "INCOMPLETE",
+              "NOT_APPLICABLE"
+            ]
+          }
+        ]
+      }
+    },
+    "permission_envelope": {
+      "type": "object",
+      "properties": {
+        "allowed_tools": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "uniqueItems": true
+        },
+        "financial_limit": {
+          "type": "number",
+          "minimum": 0
+        },
+        "external_communication_allowed": {
+          "type": "boolean"
+        },
+        "delegation_allowed": {
+          "type": "boolean"
+        }
+      }
+    },
+    "agent_controls": {
+      "type": "object",
+      "properties": {
+        "suspension_tested": {
+          "type": "boolean"
+        },
+        "escalation_path": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          ]
+        },
+        "memory_policy": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          ]
+        },
+        "agent_evaluation": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          ]
+        }
+      }
+    },
+    "decision_policy": {
+      "type": "object",
+      "properties": {
+        "human_reserved_decisions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "uniqueItems": true
+        },
+        "final_authority": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\S"
+        },
+        "recourse_available": {
+          "type": "boolean"
+        }
+      }
+    },
+    "high_impact_controls": {
+      "type": "object",
+      "properties": {
+        "intervention_feasible": {
+          "type": "boolean"
+        },
+        "independent_challenge_applicable": {
+          "type": "boolean"
+        },
+        "impact_assessment": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          ]
+        },
+        "hab_defined": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          ]
+        },
+        "human_competence": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          ]
+        },
+        "adverse_outcome_evaluation": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          ]
+        },
+        "residual_risk_acceptance": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          ]
+        },
+        "enhanced_monitoring": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          ]
+        },
+        "independent_challenge": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "minLength": 1,
+              "pattern": "\\S"
+            }
+          ]
+        }
+      }
+    },
+    "consistency_context": {
+      "type": "object",
+      "properties": {
+        "human_reserved": {
+          "type": "boolean"
+        },
+        "ai_final_authority": {
+          "type": "boolean"
+        },
+        "human_oversight_required": {
+          "type": "boolean"
+        },
+        "intervention_capacity_feasible": {
+          "type": "boolean"
+        },
+        "provider_change_re_evaluation": {
+          "type": "boolean"
+        },
+        "approved_autonomy": {
+          "type": "string",
+          "enum": [
+            "A0",
+            "A1",
+            "A2",
+            "A3",
+            "A4",
+            "A5"
+          ]
+        },
+        "observed_autonomy": {
+          "type": "string",
+          "enum": [
+            "A0",
+            "A1",
+            "A2",
+            "A3",
+            "A4",
+            "A5"
+          ]
+        },
+        "external_change_exposure": {
+          "type": "string",
+          "minLength": 1,
+          "pattern": "\\S"
+        }
+      }
+    },
+    "agent_events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "occurred_at": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "format": "date-time"
+          },
+          "action": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "tool": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "financial_amount": {
+            "type": "number",
+            "minimum": 0
+          },
+          "external_communication": {
+            "type": "boolean"
+          },
+          "delegated": {
+            "type": "boolean"
+          }
+        }
+      }
+    },
+    "decision_events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "event_id": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "occurred_at": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S",
+            "format": "date-time"
+          },
+          "decision": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          },
+          "executed_by": {
+            "type": "string",
+            "minLength": 1,
+            "pattern": "\\S"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "assessment",
+    "system",
+    "risk_profile"
+  ]
+}

--- a/schemas/assessment-result-v1.schema.json
+++ b/schemas/assessment-result-v1.schema.json
@@ -1,0 +1,349 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://eaims.org/schemas/v1/assessment-result.schema.json",
+  "title": "EAIMS 1.0 executable assessment result",
+  "type": "object",
+  "properties": {
+    "assessment_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "spec_version": {
+      "const": "1.0.0-fc16"
+    },
+    "assessment_type": {
+      "enum": [
+        "FULL",
+        "PARTIAL",
+        "TARGETED"
+      ]
+    },
+    "evidence_cutoff_time": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "system": {
+      "type": "object"
+    },
+    "risk_profile": {
+      "type": "object"
+    },
+    "capability_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "capability_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "result": {
+            "enum": [
+              "L1",
+              "L2",
+              "L3",
+              "L4",
+              "L5",
+              "INDETERMINATE",
+              "NOT_APPLICABLE",
+              "NOT_ASSESSED"
+            ]
+          },
+          "confidence": {
+            "enum": [
+              "C0",
+              "C1",
+              "C2",
+              "C3",
+              "C4"
+            ]
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "required": [
+          "capability_id",
+          "result"
+        ]
+      }
+    },
+    "requirement_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "requirement_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "result": {
+            "enum": [
+              "SATISFIED",
+              "PARTIALLY_SATISFIED",
+              "NOT_SATISFIED",
+              "INSUFFICIENT_EVIDENCE",
+              "NOT_APPLICABLE"
+            ]
+          },
+          "evidence_refs": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "required": [
+          "requirement_id",
+          "result"
+        ]
+      }
+    },
+    "gate_results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "gate_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "family": {
+            "enum": [
+              "G0",
+              "G1",
+              "G2",
+              "G3"
+            ]
+          },
+          "result": {
+            "enum": [
+              "PASS",
+              "BREACH",
+              "INCOMPLETE",
+              "NOT_APPLICABLE"
+            ]
+          },
+          "reason": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "gate_id",
+          "family",
+          "result",
+          "reason"
+        ]
+      }
+    },
+    "permission_envelope_evaluation": {
+      "type": "object"
+    },
+    "hab_evaluation": {
+      "type": "object"
+    },
+    "autonomy_debt": {
+      "type": "object"
+    },
+    "consistency_findings": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      }
+    },
+    "evidence_validation_errors": {
+      "type": "object"
+    },
+    "dimension_profile": {
+      "type": "object",
+      "additionalProperties": {
+        "type": [
+          "number",
+          "null"
+        ],
+        "minimum": 1,
+        "maximum": 5
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "properties": {
+        "capabilities_in_scope": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "applicable_capabilities": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "determinate_capabilities": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "applicable_determinate_ratio": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "critical_capabilities_assessed": {
+          "type": "boolean"
+        },
+        "dimensions_represented": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 8
+        }
+      },
+      "required": [
+        "capabilities_in_scope",
+        "applicable_capabilities",
+        "determinate_capabilities",
+        "applicable_determinate_ratio",
+        "critical_capabilities_assessed",
+        "dimensions_represented"
+      ]
+    },
+    "indicative_scoped_index": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 1,
+      "maximum": 5
+    },
+    "enterprise_index": {
+      "type": [
+        "number",
+        "null"
+      ],
+      "minimum": 1,
+      "maximum": 5
+    },
+    "enterprise_maturity_established": {
+      "type": "boolean"
+    },
+    "enterprise_band": {
+      "enum": [
+        "Initial",
+        "Emerging",
+        "Defined",
+        "Managed",
+        "Adaptive",
+        null
+      ]
+    },
+    "result_hash": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    }
+  },
+  "required": [
+    "assessment_id",
+    "spec_version",
+    "assessment_type",
+    "evidence_cutoff_time",
+    "system",
+    "risk_profile",
+    "capability_results",
+    "requirement_results",
+    "gate_results",
+    "permission_envelope_evaluation",
+    "hab_evaluation",
+    "autonomy_debt",
+    "consistency_findings",
+    "evidence_validation_errors",
+    "dimension_profile",
+    "coverage",
+    "indicative_scoped_index",
+    "enterprise_index",
+    "enterprise_maturity_established",
+    "enterprise_band",
+    "result_hash"
+  ],
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "assessment_type": {
+            "const": "TARGETED"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "indicative_scoped_index": {
+            "type": "null"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "assessment_type": {
+            "enum": [
+              "PARTIAL",
+              "TARGETED"
+            ]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "enterprise_index": {
+            "type": "null"
+          },
+          "enterprise_band": {
+            "type": "null"
+          },
+          "enterprise_maturity_established": {
+            "const": false
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "enterprise_maturity_established": {
+            "const": false
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "enterprise_index": {
+            "type": "null"
+          },
+          "enterprise_band": {
+            "type": "null"
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "assessment_type": {
+            "const": "FULL"
+          },
+          "enterprise_index": {
+            "type": "number",
+            "minimum": 1,
+            "maximum": 5
+          },
+          "enterprise_band": {
+            "type": "string"
+          },
+          "indicative_scoped_index": {
+            "type": "null"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/site/README.md
+++ b/site/README.md
@@ -1,5 +1,7 @@
 # Reference Web Interface
 
+> **Legacy v0.2.x resource.** This file does not define the EAIMS 1.0 workflow. Start with the [EAIMS 1.0 assessment guide](../docs/ASSESSMENT-V1.md).
+
 This static, dependency-free interface provides an indicative self-assessment and JSON export. It does not verify evidence and therefore does not independently establish Evidence-Based conformance.
 
 From the repository root, run:

--- a/src/eaims/cli.py
+++ b/src/eaims/cli.py
@@ -3,6 +3,7 @@ import argparse, json, sys, yaml
 
 from .engine import assess_fixture, validate_fixture
 from .report import render_markdown
+from .input_io import load_input_yaml
 from .review import validate_review_record, validate_resolution_record, aggregate_findings, apply_resolutions, review_summary, render_review_markdown
 from .legacy_compat import (
     LegacyAssessmentError, validate_legacy_assessment, score_legacy_assessment,
@@ -33,6 +34,8 @@ def main(argv: list[str] | None = None) -> int:
     rs = rsub.add_parser("summarize")
     rs.add_argument("fixture")
     rs.add_argument("--out", default="review-output")
+    rs.add_argument("--fail-on-unmet", action="store_true",
+                    help="Exit 1 when review exit criteria are not met; still write reports")
 
     # Backward-compatible v0.2.1 CLI contract already published by EAIMS.
     for name in ("validate", "score"):
@@ -46,13 +49,13 @@ def main(argv: list[str] | None = None) -> int:
     args = p.parse_args(argv)
     try:
         if args.cmd == "validate-fixture":
-            fixture = yaml.safe_load(Path(args.fixture).read_text(encoding="utf-8"))
+            fixture = load_input_yaml(args.fixture)
             errors = validate_fixture(fixture)
             print(json.dumps({"valid": not errors, "errors": errors}, ensure_ascii=False, indent=2))
             return 0 if not errors else 1
 
         if args.cmd == "assess":
-            fixture = yaml.safe_load(Path(args.fixture).read_text(encoding="utf-8"))
+            fixture = load_input_yaml(args.fixture)
             errors = validate_fixture(fixture)
             if errors:
                 print(json.dumps({"valid": False, "errors": errors}, ensure_ascii=False, indent=2), file=sys.stderr)
@@ -66,20 +69,26 @@ def main(argv: list[str] | None = None) -> int:
             return 0
 
         if args.cmd == "review" and args.review_cmd == "validate":
-            record = yaml.safe_load(Path(args.record).read_text(encoding="utf-8"))
+            record = load_input_yaml(args.record)
             errors = validate_review_record(record)
             print(json.dumps({"valid": not errors, "errors": errors}, indent=2))
             return 0 if not errors else 2
 
         if args.cmd == "review" and args.review_cmd == "summarize":
-            data = yaml.safe_load(Path(args.fixture).read_text(encoding="utf-8"))
+            data = load_input_yaml(args.fixture)
+            if not isinstance(data, dict):
+                raise ValueError("review fixture must be an object")
             records = data.get("reviews", [])
+            if not isinstance(records, list):
+                raise ValueError("reviews must be an array")
             for rec in records:
                 errors = validate_review_record(rec)
                 if errors:
                     print("Invalid review record: " + "; ".join(errors), file=sys.stderr)
                     return 2
             resolutions = data.get("resolutions", [])
+            if not isinstance(resolutions, list):
+                raise ValueError("resolutions must be an array")
             for resolution in resolutions:
                 errors = validate_resolution_record(resolution)
                 if errors:
@@ -93,7 +102,7 @@ def main(argv: list[str] | None = None) -> int:
             (out / "findings-ledger.json").write_text(json.dumps(ledger, ensure_ascii=False, indent=2), encoding="utf-8")
             (out / "review-summary.md").write_text(render_review_markdown(summary, ledger), encoding="utf-8")
             print(json.dumps({"status": summary["rc_gate"]["status"], "out": str(out)}, indent=2))
-            return 0
+            return 1 if args.fail_on_unmet and not summary["rc_gate"]["review_completed_for_rc"] else 0
 
         # Legacy v0.2.1 compatibility path.
         data = _load_json(args.assessment)

--- a/src/eaims/engine.py
+++ b/src/eaims/engine.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from .paths import ROOT
 from typing import Any
 import json, math, yaml
+from .input_validation import validate_input_structure
 
 
 LEVEL_NUM = {f"L{i}": i for i in range(1,6)}
@@ -62,7 +63,9 @@ def validate_evidence(e: dict[str, Any], cutoff: str | None = None) -> list[str]
     if e.get("nature") not in {"SUPPORTING","COUNTER","ABSENCE","CONTEXT"}: errors.append("invalid:nature")
     if not str(e.get("source", "")).strip(): errors.append("invalid:source")
     collected = e.get("collected_at")
-    if collected:
+    if not isinstance(collected, str) or not collected.strip():
+        errors.append("invalid:collected_at")
+    else:
         try:
             collected_dt = _parse_timestamp(collected)
         except (TypeError, ValueError):
@@ -494,7 +497,9 @@ def validate_fixture(fixture: dict[str, Any]) -> list[str]:
     unknown canonical references, broken evidence references, invalid assessment scope,
     and malformed timestamps are rejected before any maturity result is produced.
     """
-    errors: list[str] = []
+    errors = validate_input_structure(fixture)
+    if errors:
+        return errors
     if not isinstance(fixture, dict):
         return ["fixture must be an object"]
     assessment = fixture.get("assessment")

--- a/src/eaims/input_io.py
+++ b/src/eaims/input_io.py
@@ -1,0 +1,32 @@
+"""Load user YAML without silently replacing duplicate mapping keys."""
+from __future__ import annotations
+
+from pathlib import Path
+import yaml
+from yaml.constructor import ConstructorError
+
+
+class UniqueKeyLoader(yaml.SafeLoader):
+    pass
+
+
+def _mapping(loader, node, deep=False):
+    loader.flatten_mapping(node)
+    result = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        try:
+            duplicate = key in result
+        except TypeError as exc:
+            raise ConstructorError(None, None, "mapping keys must be scalar", key_node.start_mark) from exc
+        if duplicate:
+            raise ConstructorError(None, None, f"duplicate mapping key: {key}", key_node.start_mark)
+        result[key] = loader.construct_object(value_node, deep=deep)
+    return result
+
+
+UniqueKeyLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _mapping)
+
+
+def load_input_yaml(path: str | Path):
+    return yaml.load(Path(path).read_text(encoding="utf-8"), Loader=UniqueKeyLoader)

--- a/src/eaims/input_validation.py
+++ b/src/eaims/input_validation.py
@@ -1,0 +1,40 @@
+"""Structural validation of the v1 fixture before semantic evaluation."""
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+from jsonschema import Draft202012Validator, FormatChecker
+from .paths import ROOT
+
+
+def validate_input_structure(value: Any) -> list[str]:
+    errors = []
+    active = set()
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, float) and not math.isfinite(node):
+            errors.append(f"{path}: number must be finite")
+        elif isinstance(node, (dict, list)):
+            if id(node) in active:
+                errors.append(f"{path}: recursive data is not supported")
+                return
+            active.add(id(node))
+            entries = node.items() if isinstance(node, dict) else enumerate(node)
+            for key, child in entries:
+                if isinstance(node, dict) and not isinstance(key, str):
+                    errors.append(f"{path}: object keys must be strings")
+                walk(child, f"{path}.{key}")
+            active.remove(id(node))
+        elif node is not None and not isinstance(node, (str, int, float, bool)):
+            errors.append(f"{path}: value must be JSON-compatible")
+
+    walk(value, "$")
+    if errors:
+        return errors
+    schema = json.loads((ROOT / "schemas" / "assessment-fixture-v1.schema.json").read_text(encoding="utf-8"))
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    for error in sorted(validator.iter_errors(value), key=lambda e: tuple(map(str, e.path))):
+        path = ".".join(map(str, error.path)) or "$"
+        errors.append(f"{path}: {error.message}")
+    return errors

--- a/src/eaims/review.py
+++ b/src/eaims/review.py
@@ -5,18 +5,17 @@ from typing import Any, Iterable
 import json
 import yaml
 from jsonschema import Draft202012Validator, FormatChecker
+from .paths import ROOT
+from .input_io import load_input_yaml
 
 
 def _root() -> Path:
-    here = Path(__file__).resolve()
-    for candidate in [here.parents[2], here.parents[1], Path.cwd()]:
-        if (candidate / "spec" / "review-protocol.yaml").exists():
-            return candidate
-    return here.parents[2]
+    """Use the same installed specification root as the assessment engine."""
+    return ROOT
 
 
 def load_yaml(path: str | Path) -> Any:
-    return yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    return load_input_yaml(path)
 
 
 def validate_review_record(record: dict[str, Any], root: Path | None = None) -> list[str]:
@@ -47,8 +46,18 @@ def _finding_key(review_id: str, finding: dict[str, Any]) -> str:
 
 def aggregate_findings(records: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
     ledger = []
+    review_ids = set()
+    finding_keys = set()
     for record in records:
+        review_id = record["review_id"]
+        if review_id in review_ids:
+            raise ValueError(f"Duplicate review_id: {review_id}")
+        review_ids.add(review_id)
         for finding in record.get("findings", []):
+            key = _finding_key(review_id, finding)
+            if key in finding_keys:
+                raise ValueError(f"Duplicate finding_key: {key}")
+            finding_keys.add(key)
             ledger.append({
                 "finding_key": _finding_key(record["review_id"], finding),
                 "review_id": record["review_id"],
@@ -65,7 +74,12 @@ def aggregate_findings(records: Iterable[dict[str, Any]]) -> list[dict[str, Any]
 
 
 def apply_resolutions(ledger: list[dict[str, Any]], resolutions: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
-    by_key = {x["finding_key"]: x for x in ledger}
+    by_key = {}
+    for item in ledger:
+        key = item["finding_key"]
+        if key in by_key:
+            raise ValueError(f"Duplicate finding_key: {key}")
+        by_key[key] = dict(item)
     seen_resolution_ids=set()
     seen_findings=set()
     for r in resolutions:

--- a/tests/test_v1_input_hardening.py
+++ b/tests/test_v1_input_hardening.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+import json
+import pytest
+import yaml
+from src.eaims.engine import assess_fixture, validate_fixture, validate_evidence
+from src.eaims.cli import main
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def fixture():
+    return yaml.safe_load((ROOT / 'reference-implementations/ri-02-enterprise-service-agent/input/fixture.yaml').read_text())
+
+
+@pytest.mark.parametrize('value', ['', None, ' ', False, 0, '2026-09-09T00:00:00'])
+def test_evidence_requires_timezone_aware_collection_time(value):
+    f = fixture()
+    f['evidence'][0]['collected_at'] = value
+    assert 'invalid:collected_at' in validate_evidence(f['evidence'][0])
+    assert validate_fixture(f)
+    with pytest.raises(ValueError):
+        assess_fixture(f)
+
+
+@pytest.mark.parametrize('path,value', [
+    (('capabilities', 0, 'anchor_observed', 'L4'), 'false'),
+    (('capabilities', 0, 'operating_cycles'), -1),
+    (('capabilities', 0, 'adaptation_cycles'), 1.5),
+    (('capabilities', 0, 'capability_id'), []),
+    (('evidence', 0, 'evidence_id'), {}),
+    (('evidence', 0, 'source'), None),
+    (('requirement_results', 0, 'evidence_refs'), 'EV-1'),
+    (('system', 'agentic'), 'false'),
+    (('permission_envelope', 'delegation_allowed'), 'false'),
+    (('permission_envelope', 'financial_limit'), float('nan')),
+    (('permission_envelope', 'financial_limit'), float('inf')),
+    (('permission_envelope', 'financial_limit'), -1),
+    (('permission_envelope', 'financial_limit'), True),
+    (('gate_inputs',), ['PASS']),
+    (('gate_inputs', 'G3-01'), 1),
+    (('gate_inputs', 'G3-01'), {}),
+    (('agent_events',), [None]),
+    (('agent_events', 0, 'occurred_at'), ''),
+    (('agent_events', 0, 'financial_amount'), '100'),
+    (('risk_profile', 'impact'), []),
+])
+def test_invalid_types_rejected_before_scoring(path, value):
+    f = fixture()
+    node = f
+    for key in path[:-1]:
+        node = node[key]
+    node[path[-1]] = value
+    assert validate_fixture(f)
+    with pytest.raises(ValueError, match='Invalid EAIMS fixture'):
+        assess_fixture(f)
+
+
+def test_future_evidence_rejected_across_timezone_offsets():
+    f = fixture()
+    f['evidence'][0]['collected_at'] = '2026-09-10T04:00:00+03:30'
+    assert any('after_cutoff' in error for error in validate_fixture(f))
+
+
+def test_cyclic_yaml_and_non_string_keys_rejected():
+    f = fixture()
+    f['extension'] = f
+    assert any('recursive data' in e for e in validate_fixture(f))
+    f = fixture()
+    f['extension'] = {1: 'value'}
+    assert any('keys must be strings' in e for e in validate_fixture(f))
+
+
+def test_cli_invalid_input_reports_error_without_traceback(tmp_path, capsys):
+    f = fixture()
+    f['gate_inputs'] = [True]
+    path = tmp_path / 'bad.yaml'
+    path.write_text(yaml.safe_dump(f))
+    assert main(['assess', str(path), '--out', str(tmp_path / 'out')]) == 1
+    captured = capsys.readouterr()
+    assert 'gate_inputs' in captured.err
+    assert 'Traceback' not in captured.err
+    assert not (tmp_path / 'out').exists()
+
+
+def test_cli_rejects_duplicate_yaml_keys(tmp_path, capsys):
+    path = tmp_path / 'duplicate.yaml'
+    path.write_text('reviews: []\nreviews: []\n')
+    assert main(['review', 'summarize', str(path)]) == 2
+    assert 'duplicate mapping key' in capsys.readouterr().err
+
+
+def test_reference_results_conform_to_v1_output_schema():
+    from jsonschema import Draft202012Validator, FormatChecker
+    schema = json.loads((ROOT / 'schemas/assessment-result-v1.schema.json').read_text())
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema, format_checker=FormatChecker())
+    for path in (ROOT / 'reference-implementations').glob('*/expected/result.json'):
+        result = json.loads(path.read_text())
+        assert not list(validator.iter_errors(result))
+        if result['assessment_type'] == 'TARGETED':
+            result['enterprise_index'] = 3
+            assert list(validator.iter_errors(result))
+
+
+def test_non_json_context_rejected_before_result_hashing():
+    f = fixture()
+    f['system']['extension'] = {1, 2}
+    assert any('JSON-compatible' in e for e in validate_fixture(f))

--- a/tests/test_v1_review_hardening.py
+++ b/tests/test_v1_review_hardening.py
@@ -1,0 +1,70 @@
+from copy import deepcopy
+from pathlib import Path
+import json
+import pytest
+import yaml
+from src.eaims.cli import main
+from src.eaims.review import aggregate_findings, apply_resolutions
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def fixture():
+    return yaml.safe_load((ROOT / 'validation/review-workflow-fixture.yaml').read_text())
+
+
+def test_duplicate_review_id_rejected():
+    data = fixture()
+    records = data['reviews']
+    with pytest.raises(ValueError, match='Duplicate review_id'):
+        aggregate_findings(records + deepcopy(records))
+
+
+def test_duplicate_finding_cannot_overwrite_blocker():
+    record = fixture()['reviews'][0]
+    record['findings'][0]['severity'] = 'BLOCKER'
+    duplicate = deepcopy(record['findings'][0])
+    duplicate['severity'] = 'MINOR'
+    record['findings'].append(duplicate)
+    with pytest.raises(ValueError, match='Duplicate finding_key'):
+        aggregate_findings([record])
+
+
+def test_duplicate_ledger_key_rejected_even_without_resolutions():
+    ledger = [{'finding_key': 'R:F', 'severity': 'BLOCKER'}, {'finding_key': 'R:F', 'severity': 'MINOR'}]
+    with pytest.raises(ValueError, match='Duplicate finding_key'):
+        apply_resolutions(ledger, [])
+
+
+def test_applying_resolution_preserves_original_ledger():
+    data = fixture()
+    ledger = aggregate_findings(data['reviews'])
+    original = deepcopy(ledger)
+    updated = apply_resolutions(ledger, data['resolutions'])
+    assert ledger == original
+    assert updated[0]['resolution_status'] == 'RESOLVED'
+
+
+@pytest.mark.parametrize('unmet,strict,expected', [(True, False, 0), (True, True, 1), (False, True, 0)])
+def test_cli_review_exit_code_and_reports(tmp_path, unmet, strict, expected):
+    data = fixture()
+    if unmet:
+        data['resolutions'] = []
+    path = tmp_path / 'review.yaml'
+    path.write_text(yaml.safe_dump(data))
+    out = tmp_path / 'reports'
+    args = ['review', 'summarize', str(path), '--out', str(out)]
+    if strict:
+        args.append('--fail-on-unmet')
+    assert main(args) == expected
+    summary = json.loads((out / 'review-summary.json').read_text())
+    assert summary['rc_gate']['review_completed_for_rc'] is (not unmet)
+    assert (out / 'findings-ledger.json').exists()
+    assert (out / 'review-summary.md').exists()
+
+
+@pytest.mark.parametrize('data', [None, [], {'reviews': {}}, {'resolutions': {}}])
+def test_cli_malformed_review_structure(tmp_path, data):
+    path = tmp_path / 'review.yaml'
+    path.write_text(yaml.safe_dump(data))
+    assert main(['review', 'summarize', str(path), '--out', str(tmp_path / 'out')]) == 2


### PR DESCRIPTION
EAIMS v1 could accept evidence without a collection timestamp and ambiguous field types. Duplicate review finding keys could silently replace a blocking finding, and installed-wheel review commands did not use the shared data resolver.

This change rejects malformed v1 inputs before scoring, preserves review finding identities, and makes review commands work outside the source checkout. An optional `--fail-on-unmet` flag gives automation a nonzero status when review exit criteria are unmet while still writing reports. Duplicate YAML keys are rejected at CLI input boundaries.

It also adds dedicated v1 input/result schemas, a runnable assessment guide, clear labels on legacy resources, and an installed-wheel review smoke check in CI. Frozen normative files and the published release metadata remain unchanged; changes are recorded as Unreleased.

Validation:
- 229 tests passed, including 43 new regression/contract cases.
- Canonical specification and repository audit passed.
- Wheel built and installed in an isolated virtual environment.
- All three synthetic reference assessments ran outside the repository and matched existing golden results exactly.
- Installed review success and unmet-gate exit paths passed.
- Hosted CI must pass before merge.

These checks establish software behavior, not empirical validation or independent organizational review.