### PR TITLE
Align release-facing documentation with EAIMS 1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,18 @@
 
 > An open, vendor-neutral, evidence-grounded and executable framework for assessing and improving enterprise AI maturity while governing value, autonomy, accountability and operational risk.
 
-**Version:** 1.0.1
+**Version:** 1.1.0
 **Status:** Final release
 **Documentation and specification content:** CC BY 4.0
 **Code, tests, workflows and JSON Schemas:** Apache-2.0
 
-EAIMS 1.0 moves the project from a research-baseline maturity model toward an executable enterprise AI operating and assurance framework. It does not itself confer certification, regulatory conformity, legal compliance or safety assurance.
+EAIMS 1.1 extends the stable 1.0.x framework with an additive adversarial and agentic governance overlay. It does not itself confer certification, regulatory conformity, legal compliance or safety assurance.
+
+## EAIMS 1.1 — Adversarial & Agentic Governance
+
+The 1.1.0 release adds nine normative `ADV` requirements, strengthens two material-sourcing requirements, and extends the G3 gate family with controls for adversarial exposure, blast radius, privileged agent credentials, runtime-abuse evidence, containment, threat-intelligence disposition, and synthetic identity. Historical 1.0.x assessments keep their original semantics and are not retroactively regraded.
+
+Start with the [1.1 release notes](RELEASE-NOTES-v1.1.0.md), the [adversarial and agentic governance guide](docs/ADVERSARIAL-AGENTIC-GOVERNANCE.md), and the [1.0-to-1.1 migration guide](MIGRATION-v1.0-to-v1.1-DRAFT.md). The release is maintainer-frozen and does not claim independent third-party assessor validation.
 
 ## Canonical EAIMS 1.0
 
@@ -24,7 +30,7 @@ EAIMS 1.0 moves the project from a research-baseline maturity model toward an ex
 
 A central design principle is that AI maturity is not maximum automation. Mature organizations determine where automation creates value, where human oversight is necessary, and where accountability must remain human.
 
-## Start with EAIMS 1.0
+## Start with EAIMS
 
 Follow the [v1 assessment guide](docs/ASSESSMENT-V1.md) for installation, a runnable example, output interpretation and review automation. The reference example detects a synthetic agent exceeding its financial authority; the report identifies the breached gates so the assessor can define a corrective action.
 
@@ -58,19 +64,19 @@ These cases are synthetic and are not presented as customer deployments or empir
 The v1 validator uses `Dockerfile.validator` and runs with a least-privilege container profile:
 
 ```bash
-docker build -f Dockerfile.validator -t eaims/validator:1.0.1 .
+docker build -f Dockerfile.validator -t eaims/validator:1.1.0 .
 docker compose run --rm validator
 ```
 
 Hosted CI validates the Docker image and both Compose configurations at runtime. See `docs/PACKAGING-AND-RUNTIME-VALIDATION.md` and `VALIDATION.md` for the validation boundary.
 
-## Patch release 1.0.1
+## Release history
 
-This patch hardens input validation and review integrity, fixes installed-package review execution, and adds dedicated v1 schemas and a complete assessment guide. The normative model and three synthetic reference results remain unchanged. See [release notes](RELEASE-NOTES-v1.0.1.md).
+EAIMS 1.1.0 adds the normative adversarial and agentic overlay while preserving the frozen 1.0.x baseline. The preceding 1.0.1 patch hardened input validation and review integrity, fixed installed-package review execution, and added dedicated v1 schemas and a complete assessment guide. See the [1.1.0](RELEASE-NOTES-v1.1.0.md) and [1.0.1](RELEASE-NOTES-v1.0.1.md) release notes.
 
 ## Validation status
 
-EAIMS 1.0 is **field-informed rather than field-validated**. Its design incorporates observations from feasibility assessment, realistic synthetic reference implementations and enterprise pilot-readiness discussions. Formal multi-organization empirical validation, inter-rater reliability research and independent external review remain part of the research agenda.
+EAIMS 1.1 is **field-informed rather than field-validated**. Its design incorporates observations from feasibility assessment, realistic synthetic reference implementations, public threat-intelligence sources and enterprise pilot-readiness discussions. Formal multi-organization empirical validation, inter-rater reliability research and independent external review remain part of the research agenda.
 
 The `review/` directory provides structured adversarial questions, reviewer guidance, feedback/resolution schemas and executable BLOCKER/MAJOR exit semantics. No claim is made that independent external review has already been completed.
 
@@ -78,7 +84,7 @@ The original 1.0.0 release was promoted from `v1.0.0-rc.1` only after hosted val
 
 ## Specification provenance
 
-The current public release version is **1.0.1**. The internal normative specification provenance identifier **`1.0.0-fc16`** is intentionally retained in the frozen normative source and generated reference evidence. This preserves traceability to the exact freeze-candidate content that passed RC1 validation; it does not mean the public release remains a release candidate.
+The current public release version is **1.1.0**. The internal base-specification provenance identifier **`1.0.0-fc16`** is intentionally retained in the frozen 1.0.x normative source and generated reference evidence. EAIMS 1.1.0 applies its normative overlay additively to that base; retaining the provenance identifier does not make the public release a candidate.
 
 ## Project status and stewardship
 

--- a/VALIDATION.md
+++ b/VALIDATION.md
@@ -1,6 +1,6 @@
-# EAIMS 1.0.1 — Validation Status
+# EAIMS 1.1.0 — Validation Status
 
-## Demonstrated for the final release line
+## Demonstrated for the stable 1.0.x base
 
 - 8 dimensions, 30 canonical capabilities and 150 capability-specific maturity anchors are machine-readable.
 - The catalog contains 206 requirements, including 177 SHALL/SHALL_NOT and 80 classified critical.
@@ -19,6 +19,12 @@
 The input/review hardening changes passed 229 tests, the repository audit and canonical validation. All three reference outputs matched the existing golden JSON objects exactly. Installed-wheel assessment and review success/unmet-gate paths passed outside the repository. Hosted validation passed on the merged hardening commit: [run 34459206026](https://github.com/eaims/EAIMS/actions/runs/34459206026).
 
 Release packaging additionally checks that VERSION, Python package metadata, runtime version, citation and container image versions agree. Publication is gated on successful CI for the exact release commit, including wheel installation, dependency audit and Docker/Compose execution.
+
+## Release 1.1.0 validation
+
+The additive adversarial and agentic governance overlay passed the full repository test suite, canonical validation, frozen 1.0 reference-output regression, candidate audit, release-readiness audit, and reference/IP hygiene audit. Its structured validation covers nine new ADV requirements, the MSP-005/MSP-008 amendments, G3-13 through G3-17, activation and applicability, evidence expectations, machine-verification rules, gate effects, and positive/negative fixtures.
+
+The release is **maintainer-frozen**. Independent assessor calibration, multi-organization field validation, and empirical inter-rater measurement remain post-release work; no independent third-party validation, accreditation, certification, regulatory approval, or endorsement is claimed.
 
 ## Original 1.0.0 hosted release validation
 
@@ -87,7 +93,7 @@ The following are **not** established by the current release evidence:
 - representative industry benchmarking;
 - external independent review completion.
 
-EAIMS 1.0 is therefore described as **field-informed rather than field-validated**. Its design incorporates feasibility observations, realistic synthetic reference implementations and enterprise pilot-readiness inputs. Formal multi-organization validation remains part of the research agenda.
+EAIMS 1.1 is therefore described as **field-informed rather than field-validated**. Its design incorporates feasibility observations, realistic synthetic reference implementations, public threat-intelligence sources and enterprise pilot-readiness inputs. Formal multi-organization validation remains part of the research agenda.
 
 ## Independent-review readiness
 
@@ -101,4 +107,4 @@ These repository checks are not a substitute for jurisdiction-specific legal adv
 
 ## Version and provenance
 
-The public release version is **1.0.1**. The frozen normative source retains the internal provenance identifier **`1.0.0-fc16`** so that generated evidence and the exact content validated during RC1 remain traceable. No substantive normative change is implied by promotion from the validated RC1 content to the final public version.
+The public release version is **1.1.0**. The frozen 1.0.x base retains the internal provenance identifier **`1.0.0-fc16`** so that generated evidence and the exact content validated during RC1 remain traceable. The normative 1.1 overlay is additive and does not rewrite historical 1.0.x assessment semantics.

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -21,3 +21,14 @@ def test_public_release_versions_agree():
         for service in data['services'].values():
             assert service['image'] == f'eaims/validator:{version}'
     assert (ROOT / f'RELEASE-NOTES-v{version}.md').is_file()
+
+
+def test_release_facing_documents_match_public_version():
+    version = (ROOT / 'VERSION').read_text().strip()
+    readme = (ROOT / 'README.md').read_text(encoding='utf-8')
+    validation = (ROOT / 'VALIDATION.md').read_text(encoding='utf-8')
+    assert f'**Version:** {version}' in readme
+    assert f'The current public release version is **{version}**' in readme
+    assert f'eaims/validator:{version}' in readme
+    assert validation.startswith(f'# EAIMS {version} — Validation Status')
+    assert f'The public release version is **{version}**' in validation

--- a/tools/prepush_audit.py
+++ b/tools/prepush_audit.py
@@ -60,6 +60,19 @@ release_date=str(citation_data.get('date-released',''))
 if not re.fullmatch(r'\d{4}-\d{2}-\d{2}', release_date):
     errors.append('CITATION.cff release date missing or invalid')
 
+readme=(ROOT/'README.md').read_text(encoding='utf-8')
+validation_doc=(ROOT/'VALIDATION.md').read_text(encoding='utf-8')
+if f'**Version:** {EXPECTED_RELEASE}' not in readme:
+    errors.append('README public version mismatch')
+if f'The current public release version is **{EXPECTED_RELEASE}**' not in readme:
+    errors.append('README provenance version mismatch')
+if f'eaims/validator:{EXPECTED_RELEASE}' not in readme:
+    errors.append('README Docker image version mismatch')
+if not validation_doc.startswith(f'# EAIMS {EXPECTED_RELEASE} — Validation Status'):
+    errors.append('VALIDATION.md heading version mismatch')
+if f'The public release version is **{EXPECTED_RELEASE}**' not in validation_doc:
+    errors.append('VALIDATION.md provenance version mismatch')
+
 # Active-stage files must not carry stale pre-FC16 candidate tags.
 for rel in ['README.md','VALIDATION.md','pyproject.toml','docker-compose.yml','docker-compose.reference.yml','research/EVOLUTION-0.2x-to-1.0.md']:
     text=(ROOT/rel).read_text()


### PR DESCRIPTION
## Summary
- update README and validation status from 1.0.1 to the published 1.1.0 release
- surface the adversarial and agentic governance overlay and its validation boundary
- align the documented Docker image tag with VERSION
- add automated release-document version consistency checks

## Validation
- `python tools/prepush_audit.py` — PASS
- `eaims-validate` — PASS
- `pytest -q` — 286 passed
- all EAIMS 1.1 candidate, reference/IP, and release-readiness audits — PASS
- wheel build and standalone installed-wheel CLI smoke tests — PASS

The existing `v1.1.0` tag remains unchanged.